### PR TITLE
trie: rename vars: remove `Elt`

### DIFF
--- a/array/compact.go
+++ b/array/compact.go
@@ -21,7 +21,7 @@ type CompactedArray struct {
 
 type CompactedArray struct {
 	prototype.CompactedArray
-	EltConverter
+	Converter
 }
 
 var bmWidth = uint32(64) // how many bits of an uint64 == 2 ^ 6
@@ -71,7 +71,7 @@ func (sa *CompactedArray) Init(index []uint32, _elts interface{}) error {
 
 	sa.Bitmaps = make([]uint64, bmCnt)
 	sa.Offsets = make([]uint32, bmCnt)
-	sa.Elts = make([]byte, 0, nElts*sa.GetMarshaledEltSize(nil))
+	sa.Elts = make([]byte, 0, nElts*sa.GetMarshaledSize(nil))
 
 	var prevIndex uint32
 	for i := 0; i < len(index); i++ {
@@ -80,7 +80,7 @@ func (sa *CompactedArray) Init(index []uint32, _elts interface{}) error {
 		}
 
 		ee := rElts.Index(i).Interface()
-		sa.appendElt(index[i], sa.MarshalElt(ee))
+		sa.appendElt(index[i], sa.Marshal(ee))
 
 		prevIndex = index[i]
 	}
@@ -104,9 +104,9 @@ func (sa *CompactedArray) Get(idx uint32) interface{} {
 	base := sa.Offsets[iBm]
 	cnt1 := bit.PopCnt64Before(bmWord, iBit)
 
-	stIdx := sa.GetMarshaledEltSize(nil) * (base + cnt1)
+	stIdx := sa.GetMarshaledSize(nil) * (base + cnt1)
 
-	_, val := sa.UnmarshalElt(sa.Elts[stIdx:])
+	_, val := sa.Unmarshal(sa.Elts[stIdx:])
 	return val
 }
 

--- a/array/compact_test.go
+++ b/array/compact_test.go
@@ -14,7 +14,7 @@ import (
 
 func NewU32(index []uint32, elts []uint32) (*CompactedArray, error) {
 
-	ca := CompactedArray{EltConverter: U32Conv{}}
+	ca := CompactedArray{Converter: U32Conv{}}
 	err := ca.Init(index, elts)
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func BenchmarkInit(b *testing.B) {
 
 func newByte(eSize uint32, index []uint32, elts [][]byte) (*CompactedArray, error) {
 
-	ca := CompactedArray{EltConverter: ByteConv{EltSize: eSize}}
+	ca := CompactedArray{Converter: ByteConv{EltSize: eSize}}
 	err := ca.Init(index, elts)
 	if err != nil {
 		return nil, err

--- a/array/converter.go
+++ b/array/converter.go
@@ -4,45 +4,45 @@ import (
 	"encoding/binary"
 )
 
-// A EltConverter is used to convert one element between serialized byte stream
+// A Converter is used to convert one element between serialized byte stream
 // and in-memory data structure
-type EltConverter interface {
-	MarshalElt(interface{}) []byte
-	UnmarshalElt([]byte) (uint32, interface{})
+type Converter interface {
+	Marshal(interface{}) []byte
+	Unmarshal([]byte) (uint32, interface{})
 
 	// Marshaled element may be var-length.
 	// This function is used to determine element size without the need of
 	// unmarshaling it.
-	GetMarshaledEltSize([]byte) uint32
+	GetMarshaledSize([]byte) uint32
 }
 
 type U16Conv struct{}
 
-func (c U16Conv) MarshalElt(d interface{}) []byte {
+func (c U16Conv) Marshal(d interface{}) []byte {
 	b := make([]byte, 2)
 	binary.LittleEndian.PutUint16(b, d.(uint16))
 	return b
 }
 
-func (c U16Conv) UnmarshalElt(b []byte) (uint32, interface{}) {
+func (c U16Conv) Unmarshal(b []byte) (uint32, interface{}) {
 	elt := binary.LittleEndian.Uint16(b[:2])
 
 	return 2, elt
 }
 
-func (c U16Conv) GetMarshaledEltSize(b []byte) uint32 {
+func (c U16Conv) GetMarshaledSize(b []byte) uint32 {
 	return 2
 }
 
 type U32Conv struct{}
 
-func (c U32Conv) MarshalElt(d interface{}) []byte {
+func (c U32Conv) Marshal(d interface{}) []byte {
 	b := make([]byte, 4)
 	binary.LittleEndian.PutUint32(b, d.(uint32))
 	return b
 }
 
-func (c U32Conv) UnmarshalElt(b []byte) (uint32, interface{}) {
+func (c U32Conv) Unmarshal(b []byte) (uint32, interface{}) {
 
 	size := uint32(4)
 	s := b[:size]
@@ -51,7 +51,7 @@ func (c U32Conv) UnmarshalElt(b []byte) (uint32, interface{}) {
 	return size, d
 }
 
-func (c U32Conv) GetMarshaledEltSize(b []byte) uint32 {
+func (c U32Conv) GetMarshaledSize(b []byte) uint32 {
 	return 4
 }
 
@@ -59,29 +59,29 @@ type ByteConv struct {
 	EltSize uint32
 }
 
-func (c ByteConv) MarshalElt(d interface{}) []byte {
+func (c ByteConv) Marshal(d interface{}) []byte {
 	return d.([]byte)
 }
 
-func (c ByteConv) UnmarshalElt(b []byte) (uint32, interface{}) {
+func (c ByteConv) Unmarshal(b []byte) (uint32, interface{}) {
 	s := b[:c.EltSize]
 	return c.EltSize, s
 }
 
-func (c ByteConv) GetMarshaledEltSize(b []byte) uint32 {
+func (c ByteConv) GetMarshaledSize(b []byte) uint32 {
 	return c.EltSize
 }
 
 type U32to3ByteConv struct{}
 
-func (c U32to3ByteConv) MarshalElt(d interface{}) []byte {
+func (c U32to3ByteConv) Marshal(d interface{}) []byte {
 	size := 4
 	b := make([]byte, size)
 	binary.LittleEndian.PutUint32(b, d.(uint32))
 	return b[:3]
 }
 
-func (c U32to3ByteConv) UnmarshalElt(b []byte) (uint32, interface{}) {
+func (c U32to3ByteConv) Unmarshal(b []byte) (uint32, interface{}) {
 	size := uint32(4)
 	s := make([]byte, size)
 	copy(s[:3], b)
@@ -90,6 +90,6 @@ func (c U32to3ByteConv) UnmarshalElt(b []byte) (uint32, interface{}) {
 	return size, d
 }
 
-func (c U32to3ByteConv) GetMarshaledEltSize(b []byte) uint32 {
+func (c U32to3ByteConv) GetMarshaledSize(b []byte) uint32 {
 	return uint32(3)
 }

--- a/serialize/serialize_test.go
+++ b/serialize/serialize_test.go
@@ -162,7 +162,7 @@ func TestMarshalUnMarshalHeader(t *testing.T) {
 func TestMarshalUnMarshal(t *testing.T) {
 	index := []uint32{10, 20, 30, 40, 50, 60}
 
-	sArray := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	sArray := &array.CompactedArray{Converter: array.U32Conv{}}
 	err := sArray.Init(index, index)
 	if err != nil {
 		t.Fatalf("failed to init compacted array")
@@ -205,7 +205,7 @@ func TestMarshalUnMarshal(t *testing.T) {
 	}
 	defer reader.Close()
 
-	rSArray := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	rSArray := &array.CompactedArray{Converter: array.U32Conv{}}
 
 	err = Unmarshal(reader, rSArray)
 	if err != nil {
@@ -241,7 +241,7 @@ func TestUnMarshalFromIncompleteReader(t *testing.T) {
 
 	index := []uint32{10, 20, 30, 40, 50, 60}
 
-	sArray := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	sArray := &array.CompactedArray{Converter: array.U32Conv{}}
 	err := sArray.Init(index, index)
 	if err != nil {
 		t.Fatalf("failed to init compacted array")
@@ -263,7 +263,7 @@ func TestUnMarshalFromIncompleteReader(t *testing.T) {
 
 	// unmarshal
 
-	rSArray := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	rSArray := &array.CompactedArray{Converter: array.U32Conv{}}
 
 	err = Unmarshal(rw, rSArray)
 	if err != nil {
@@ -278,13 +278,13 @@ func TestMarshalAtUnMarshalAt(t *testing.T) {
 	index1 := []uint32{10, 20, 30, 40, 50, 60}
 	index2 := []uint32{15, 25, 35, 45, 55, 65}
 
-	sArray1 := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	sArray1 := &array.CompactedArray{Converter: array.U32Conv{}}
 	err := sArray1.Init(index1, index1)
 	if err != nil {
 		t.Fatalf("failed to init compacted array")
 	}
 
-	sArray2 := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	sArray2 := &array.CompactedArray{Converter: array.U32Conv{}}
 	err = sArray2.Init(index2, index2)
 	if err != nil {
 		t.Fatalf("failed to init compacted array")
@@ -319,7 +319,7 @@ func TestMarshalAtUnMarshalAt(t *testing.T) {
 	}
 	defer reader.Close()
 
-	rSArray1 := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	rSArray1 := &array.CompactedArray{Converter: array.U32Conv{}}
 	_, err = UnmarshalAt(reader, offset1, rSArray1)
 	if err != nil {
 		t.Fatalf("failed to load data: %v", err)
@@ -327,7 +327,7 @@ func TestMarshalAtUnMarshalAt(t *testing.T) {
 
 	checkCompactedArray(index1, rSArray1, sArray1, t)
 
-	rSArray2 := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	rSArray2 := &array.CompactedArray{Converter: array.U32Conv{}}
 	_, err = UnmarshalAt(reader, offset2, rSArray2)
 	if err != nil {
 		t.Fatalf("failed to load data: %v", err)
@@ -397,7 +397,7 @@ func TestWriteAtReadAt(t *testing.T) {
 	rw := &testWriterReader{}
 	index1 := []uint32{10, 20, 30, 40, 50, 60}
 
-	wArr := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	wArr := &array.CompactedArray{Converter: array.U32Conv{}}
 	err := wArr.Init(index1, index1)
 	if err != nil {
 		t.Fatalf("failed to init compacted array")
@@ -408,7 +408,7 @@ func TestWriteAtReadAt(t *testing.T) {
 		t.Fatalf("failed to store compacted array: %v", err)
 	}
 
-	rArr := &array.CompactedArray{EltConverter: array.U32Conv{}}
+	rArr := &array.CompactedArray{Converter: array.U32Conv{}}
 	_, err = UnmarshalAt(rw, 10, rArr)
 	if err != nil {
 		t.Fatalf("failed to load data: %v", err)

--- a/trie/compact.go
+++ b/trie/compact.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"io"
-	"os"
-	"unsafe"
 	"github.com/openacid/slim/array"
 	"github.com/openacid/slim/bit"
 	"github.com/openacid/slim/serialize"
+	"io"
+	"os"
+	"unsafe"
 )
 
 const (
@@ -38,7 +38,7 @@ type ChildConv struct {
 	child *children
 }
 
-func (c ChildConv) MarshalElt(d interface{}) []byte {
+func (c ChildConv) Marshal(d interface{}) []byte {
 	child := d.(*children)
 
 	b := make([]byte, 4)
@@ -48,7 +48,7 @@ func (c ChildConv) MarshalElt(d interface{}) []byte {
 	return b
 }
 
-func (c ChildConv) UnmarshalElt(b []byte) (uint32, interface{}) {
+func (c ChildConv) Unmarshal(b []byte) (uint32, interface{}) {
 
 	c.child.Bitmap = binary.LittleEndian.Uint16(b[:2])
 	c.child.Offset = binary.LittleEndian.Uint16(b[2:4])
@@ -56,7 +56,7 @@ func (c ChildConv) UnmarshalElt(b []byte) (uint32, interface{}) {
 	return uint32(4), c.child
 }
 
-func (c ChildConv) GetMarshaledEltSize(b []byte) uint32 {
+func (c ChildConv) GetMarshaledSize(b []byte) uint32 {
 	return uint32(4)
 }
 
@@ -64,27 +64,27 @@ type StepConv struct {
 	step *uint16
 }
 
-func (c StepConv) MarshalElt(d interface{}) []byte {
+func (c StepConv) Marshal(d interface{}) []byte {
 	b := make([]byte, 2)
 	binary.LittleEndian.PutUint16(b, *(d.(*uint16)))
 	return b
 }
 
-func (c StepConv) UnmarshalElt(b []byte) (uint32, interface{}) {
+func (c StepConv) Unmarshal(b []byte) (uint32, interface{}) {
 	*c.step = binary.LittleEndian.Uint16(b[:2])
 	return uint32(2), c.step
 }
 
-func (c StepConv) GetMarshaledEltSize(b []byte) uint32 {
+func (c StepConv) GetMarshaledSize(b []byte) uint32 {
 	return uint32(2)
 }
 
-func NewCompactedTrie(c array.EltConverter) *CompactedTrie {
+func NewCompactedTrie(c array.Converter) *CompactedTrie {
 	var step uint16 = 0
 	ct := &CompactedTrie{
-		Children: array.CompactedArray{EltConverter: ChildConv{child: &children{}}},
-		Steps:    array.CompactedArray{EltConverter: StepConv{step: &step}},
-		Leaves:   array.CompactedArray{EltConverter: c},
+		Children: array.CompactedArray{Converter: ChildConv{child: &children{}}},
+		Steps:    array.CompactedArray{Converter: StepConv{step: &step}},
+		Leaves:   array.CompactedArray{Converter: c},
 	}
 
 	return ct

--- a/trie/compact_test.go
+++ b/trie/compact_test.go
@@ -3,10 +3,10 @@ package trie
 import (
 	"bytes"
 	"encoding/binary"
+	"github.com/openacid/slim/array"
 	"os"
 	"reflect"
 	"testing"
-	"github.com/openacid/slim/array"
 
 	proto "github.com/golang/protobuf/proto"
 )
@@ -24,14 +24,14 @@ just to make it easier to test it as a number of uint64
 */
 type TestIntConv struct{}
 
-func (c TestIntConv) MarshalElt(d interface{}) []byte {
+func (c TestIntConv) Marshal(d interface{}) []byte {
 	b := make([]byte, 8)
 	v := uint64(d.(int))
 	binary.LittleEndian.PutUint64(b, v)
 	return b
 }
 
-func (c TestIntConv) UnmarshalElt(b []byte) (uint32, interface{}) {
+func (c TestIntConv) Unmarshal(b []byte) (uint32, interface{}) {
 
 	size := uint32(8)
 	s := b[:size]
@@ -40,7 +40,7 @@ func (c TestIntConv) UnmarshalElt(b []byte) (uint32, interface{}) {
 	return size, int(d)
 }
 
-func (c TestIntConv) GetMarshaledEltSize(b []byte) uint32 {
+func (c TestIntConv) GetMarshaledSize(b []byte) uint32 {
 	return 8
 }
 

--- a/trie/utils.go
+++ b/trie/utils.go
@@ -33,7 +33,7 @@ func (kv testKV) Less(than btree.Item) bool {
 	return false
 }
 
-func (c testKVConv) MarshalElt(d interface{}) []byte {
+func (c testKVConv) Marshal(d interface{}) []byte {
 
 	elt := d.(*testKV)
 
@@ -45,7 +45,7 @@ func (c testKVConv) MarshalElt(d interface{}) []byte {
 	return b
 }
 
-func (c testKVConv) UnmarshalElt(b []byte) (uint32, interface{}) {
+func (c testKVConv) Unmarshal(b []byte) (uint32, interface{}) {
 
 	size := uint32(8)
 	s := b[:size]
@@ -64,7 +64,7 @@ func (c testKVConv) UnmarshalElt(b []byte) (uint32, interface{}) {
 	return uint32(8), eltP
 }
 
-func (c testKVConv) GetMarshaledEltSize(b []byte) uint32 {
+func (c testKVConv) GetMarshaledSize(b []byte) uint32 {
 	return uint32(8)
 }
 


### PR DESCRIPTION
For converter, the term `Elt` in all of the names does not provide any meaningful information. Remove it.
`EltConverter`, `GetMarshaledEltSize`, `MarshalElt` and `UnMarshalElt`

- [x] Refactoring


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

