### PR TITLE
array: converter.go add doc use int type for Unmarshal() return value

### DIFF
--- a/array/compact.go
+++ b/array/compact.go
@@ -8,17 +8,6 @@ import (
 	"github.com/openacid/slim/prototype"
 )
 
-/*
-type CompactedArray struct {
-	Cnt     uint32 // current number of elts
-	EltSize uint32
-
-	Bitmaps []uint64 // bitmaps[] about which index has elt
-	Offsets []uint32 // index offset in `elts` for bitmap[i]
-	Elts    []byte
-}
-*/
-
 type CompactedArray struct {
 	prototype.CompactedArray
 	Converter
@@ -56,9 +45,9 @@ func (sa *CompactedArray) Init(index []uint32, _elts interface{}) error {
 		panic("input is not a slice")
 	}
 
-	nElts := uint32(rElts.Len())
+	nElts := rElts.Len()
 
-	if uint32(len(index)) != nElts {
+	if len(index) != nElts {
 		return ErrIndexLen
 	}
 
@@ -104,7 +93,7 @@ func (sa *CompactedArray) Get(idx uint32) interface{} {
 	base := sa.Offsets[iBm]
 	cnt1 := bit.PopCnt64Before(bmWord, iBit)
 
-	stIdx := sa.GetMarshaledSize(nil) * (base + cnt1)
+	stIdx := uint32(sa.GetMarshaledSize(nil)) * (base + cnt1)
 
 	_, val := sa.Unmarshal(sa.Elts[stIdx:])
 	return val

--- a/array/compact_test.go
+++ b/array/compact_test.go
@@ -142,7 +142,7 @@ func BenchmarkInit(b *testing.B) {
 
 }
 
-func newByte(eSize uint32, index []uint32, elts [][]byte) (*CompactedArray, error) {
+func newByte(eSize int, index []uint32, elts [][]byte) (*CompactedArray, error) {
 
 	ca := CompactedArray{Converter: ByteConv{EltSize: eSize}}
 	err := ca.Init(index, elts)
@@ -160,7 +160,7 @@ func readRss() uint64 {
 	return stats.Alloc
 }
 
-func makeTestData(eltSize, cnt uint32) [][]byte {
+func makeTestData(eltSize int, cnt uint32) [][]byte {
 	eltsData := make([][]byte, cnt)
 
 	for i := uint32(0); i < cnt; i++ {
@@ -185,7 +185,7 @@ func makeTestIndex(maxIdx, idxDis uint32) []uint32 {
 
 func BenchmarkMemOverhead(b *testing.B) {
 	var cases = []struct {
-		eltSize uint32
+		eltSize int
 		maxIdx  uint32
 	}{
 		{1, 1 << 16},
@@ -227,7 +227,7 @@ func BenchmarkMemOverhead(b *testing.B) {
 			var _ []uint64 = sca[0].Bitmaps
 
 			totalSize := rss2 - rss1
-			dataAvgSize := uint64(eltSize * eltCnt)
+			dataAvgSize := uint64(eltSize) * uint64(eltCnt)
 			caAvgSize := totalSize / uint64(caCnt)
 			overhead := float64(caAvgSize) / float64(dataAvgSize)
 

--- a/array/converter.go
+++ b/array/converter.go
@@ -5,75 +5,98 @@ import (
 )
 
 // A Converter is used to convert one element between serialized byte stream
-// and in-memory data structure
+// and in-memory data structure.
 type Converter interface {
+	// Convert into serialised byte stream.
 	Marshal(interface{}) []byte
-	Unmarshal([]byte) (uint32, interface{})
+
+	// Read byte stream and convert it back to typed data.
+	Unmarshal([]byte) (int, interface{})
 
 	// Marshaled element may be var-length.
 	// This function is used to determine element size without the need of
 	// unmarshaling it.
-	GetMarshaledSize([]byte) uint32
+	GetMarshaledSize([]byte) int
 }
 
+// U16Conv converts uint16 to slice of 2 bytes and back.
 type U16Conv struct{}
 
+// Marshal converts uint16 to slice of 2 bytes.
 func (c U16Conv) Marshal(d interface{}) []byte {
 	b := make([]byte, 2)
 	binary.LittleEndian.PutUint16(b, d.(uint16))
 	return b
 }
 
-func (c U16Conv) Unmarshal(b []byte) (uint32, interface{}) {
+// Unmarshal converts slice of 2 bytes to uint16.
+// It returns number bytes consumed and an uint16.
+func (c U16Conv) Unmarshal(b []byte) (int, interface{}) {
 	elt := binary.LittleEndian.Uint16(b[:2])
 
 	return 2, elt
 }
 
-func (c U16Conv) GetMarshaledSize(b []byte) uint32 {
+// GetMarshaledSize returns 2.
+func (c U16Conv) GetMarshaledSize(b []byte) int {
 	return 2
 }
 
+// U32Conv converts uint32 to slice of 4 bytes and back.
 type U32Conv struct{}
 
+// Marshal converts uint32 to slice of 4 bytes.
 func (c U32Conv) Marshal(d interface{}) []byte {
 	b := make([]byte, 4)
 	binary.LittleEndian.PutUint32(b, d.(uint32))
 	return b
 }
 
-func (c U32Conv) Unmarshal(b []byte) (uint32, interface{}) {
+// Unmarshal converts slice of 4 bytes to uint32.
+// It returns number bytes consumed and an uint32.
+func (c U32Conv) Unmarshal(b []byte) (int, interface{}) {
 
-	size := uint32(4)
+	size := int(4)
 	s := b[:size]
 
 	d := binary.LittleEndian.Uint32(s)
 	return size, d
 }
 
-func (c U32Conv) GetMarshaledSize(b []byte) uint32 {
+// GetMarshaledSize returns 4.
+func (c U32Conv) GetMarshaledSize(b []byte) int {
 	return 4
 }
 
+// ByteConv converts a byte slice into fixed length slice.
+// Result slice length is defined by ByteConv.EltSize .
 type ByteConv struct {
-	EltSize uint32
+	EltSize int
 }
 
+// Marshal converts byte slice to byte slice.
 func (c ByteConv) Marshal(d interface{}) []byte {
 	return d.([]byte)
 }
 
-func (c ByteConv) Unmarshal(b []byte) (uint32, interface{}) {
+// Unmarshal copies fixed length slice out of source byte slice.
+func (c ByteConv) Unmarshal(b []byte) (int, interface{}) {
+	// TODO: converted value should be copied. referencing source data is dangerous.
 	s := b[:c.EltSize]
 	return c.EltSize, s
 }
 
-func (c ByteConv) GetMarshaledSize(b []byte) uint32 {
+// GetMarshaledSize returns c.EltSize
+func (c ByteConv) GetMarshaledSize(b []byte) int {
 	return c.EltSize
 }
 
+// U32to3ByteConv converts uint32 to a slice of 3 bytes and back.
+//
+// Thus the int passed in should be smaller than 2^24.
 type U32to3ByteConv struct{}
 
+// Marshal converts uint32 to a slice of 3 bytes.
 func (c U32to3ByteConv) Marshal(d interface{}) []byte {
 	size := 4
 	b := make([]byte, size)
@@ -81,8 +104,9 @@ func (c U32to3ByteConv) Marshal(d interface{}) []byte {
 	return b[:3]
 }
 
-func (c U32to3ByteConv) Unmarshal(b []byte) (uint32, interface{}) {
-	size := uint32(4)
+// Unmarshal converts slice of 3 bytes to a uint32.
+func (c U32to3ByteConv) Unmarshal(b []byte) (int, interface{}) {
+	size := 4
 	s := make([]byte, size)
 	copy(s[:3], b)
 
@@ -90,6 +114,7 @@ func (c U32to3ByteConv) Unmarshal(b []byte) (uint32, interface{}) {
 	return size, d
 }
 
-func (c U32to3ByteConv) GetMarshaledSize(b []byte) uint32 {
-	return uint32(3)
+// GetMarshaledSize returns 3
+func (c U32to3ByteConv) GetMarshaledSize(b []byte) int {
+	return int(3)
 }

--- a/int-types.md
+++ b/int-types.md
@@ -1,0 +1,28 @@
+# Choose appropriate integer types
+
+## Signed integer
+
+Signed int is used as arithmetic data.
+Such as size, length, array index etc.
+
+**Do not use unsigned int if possible**.
+Minus operation with unsigned int overflows.
+E.g.:
+
+```go
+var a uint32 = 3
+var b uint32 = 5
+
+fmt.Println(a - b)
+// Output: 4294967294
+```
+
+-   `int` for in-memory size, length.
+
+-   `int64` for large size, offset etc.
+
+## Unsigned integer
+
+Unsigned int is used as non-arithmetic data, such as bitmap, bit mask etc.
+
+-   `uint64` for bitmap etc.

--- a/trie/compact.go
+++ b/trie/compact.go
@@ -48,16 +48,16 @@ func (c ChildConv) Marshal(d interface{}) []byte {
 	return b
 }
 
-func (c ChildConv) Unmarshal(b []byte) (uint32, interface{}) {
+func (c ChildConv) Unmarshal(b []byte) (int, interface{}) {
 
 	c.child.Bitmap = binary.LittleEndian.Uint16(b[:2])
 	c.child.Offset = binary.LittleEndian.Uint16(b[2:4])
 
-	return uint32(4), c.child
+	return 4, c.child
 }
 
-func (c ChildConv) GetMarshaledSize(b []byte) uint32 {
-	return uint32(4)
+func (c ChildConv) GetMarshaledSize(b []byte) int {
+	return 4
 }
 
 type StepConv struct {
@@ -70,13 +70,13 @@ func (c StepConv) Marshal(d interface{}) []byte {
 	return b
 }
 
-func (c StepConv) Unmarshal(b []byte) (uint32, interface{}) {
+func (c StepConv) Unmarshal(b []byte) (int, interface{}) {
 	*c.step = binary.LittleEndian.Uint16(b[:2])
-	return uint32(2), c.step
+	return 2, c.step
 }
 
-func (c StepConv) GetMarshaledSize(b []byte) uint32 {
-	return uint32(2)
+func (c StepConv) GetMarshaledSize(b []byte) int {
+	return 2
 }
 
 func NewCompactedTrie(c array.Converter) *CompactedTrie {
@@ -184,7 +184,7 @@ func (st *CompactedTrie) Search(key []byte) (ltVal, eqVal, gtVal interface{}) {
 	for idx := uint16(0); ; {
 		var word byte
 		if uint16(len(key)) == idx {
-			word = byte(LeafWord)
+			word = LeafWord
 		} else {
 			word = (uint8(key[idx]) & WordMask)
 		}

--- a/trie/compact_test.go
+++ b/trie/compact_test.go
@@ -31,16 +31,16 @@ func (c TestIntConv) Marshal(d interface{}) []byte {
 	return b
 }
 
-func (c TestIntConv) Unmarshal(b []byte) (uint32, interface{}) {
+func (c TestIntConv) Unmarshal(b []byte) (int, interface{}) {
 
-	size := uint32(8)
+	size := 8
 	s := b[:size]
 
 	d := binary.LittleEndian.Uint64(s)
 	return size, int(d)
 }
 
-func (c TestIntConv) GetMarshaledSize(b []byte) uint32 {
+func (c TestIntConv) GetMarshaledSize(b []byte) int {
 	return 8
 }
 
@@ -186,11 +186,11 @@ func TestCompactedTrie(t *testing.T) {
 				4,
 			},
 			expected: []ExpectKeyType{
-				ExpectKeyType{[]byte{1, 2, 3}, CompactedExpectType{nil, 0, 1}},
-				ExpectKeyType{[]byte{1, 2, 4}, CompactedExpectType{0, 1, 2}},
-				ExpectKeyType{[]byte{2, 3, 4}, CompactedExpectType{1, 2, 3}},
-				ExpectKeyType{[]byte{2, 3, 5}, CompactedExpectType{2, 3, 4}},
-				ExpectKeyType{[]byte{3, 4, 5}, CompactedExpectType{3, 4, nil}},
+				{[]byte{1, 2, 3}, CompactedExpectType{nil, 0, 1}},
+				{[]byte{1, 2, 4}, CompactedExpectType{0, 1, 2}},
+				{[]byte{2, 3, 4}, CompactedExpectType{1, 2, 3}},
+				{[]byte{2, 3, 5}, CompactedExpectType{2, 3, 4}},
+				{[]byte{3, 4, 5}, CompactedExpectType{3, 4, nil}},
 			},
 		},
 		{
@@ -213,13 +213,13 @@ func TestCompactedTrie(t *testing.T) {
 				6,
 			},
 			expected: []ExpectKeyType{
-				ExpectKeyType{[]byte{1, 2, 3}, CompactedExpectType{nil, 0, 1}},
-				ExpectKeyType{[]byte{1, 2, 3, 4}, CompactedExpectType{0, 1, 2}},
-				ExpectKeyType{[]byte{2, 3}, CompactedExpectType{1, 2, 3}},
-				ExpectKeyType{[]byte{2, 3, 0}, CompactedExpectType{2, 3, 4}},
-				ExpectKeyType{[]byte{2, 3, 4}, CompactedExpectType{3, 4, 5}},
-				ExpectKeyType{[]byte{2, 3, 4, 5}, CompactedExpectType{4, 5, 6}},
-				ExpectKeyType{[]byte{2, 3, 15}, CompactedExpectType{5, 6, nil}},
+				{[]byte{1, 2, 3}, CompactedExpectType{nil, 0, 1}},
+				{[]byte{1, 2, 3, 4}, CompactedExpectType{0, 1, 2}},
+				{[]byte{2, 3}, CompactedExpectType{1, 2, 3}},
+				{[]byte{2, 3, 0}, CompactedExpectType{2, 3, 4}},
+				{[]byte{2, 3, 4}, CompactedExpectType{3, 4, 5}},
+				{[]byte{2, 3, 4, 5}, CompactedExpectType{4, 5, 6}},
+				{[]byte{2, 3, 15}, CompactedExpectType{5, 6, nil}},
 			},
 		},
 	}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -36,11 +36,11 @@ func TestTrie(t *testing.T) {
 				4,
 			},
 			expected: []ExpectType{
-				ExpectType{[]byte{'a', 'b', 'c'}, 0},
-				ExpectType{[]byte{'a', 'b', 'd'}, 1},
-				ExpectType{[]byte{'b', 'c', 'd'}, 2},
-				ExpectType{[]byte{'b', 'c', 'e'}, 3},
-				ExpectType{[]byte{'c', 'd', 'e'}, 4},
+				{[]byte{'a', 'b', 'c'}, 0},
+				{[]byte{'a', 'b', 'd'}, 1},
+				{[]byte{'b', 'c', 'd'}, 2},
+				{[]byte{'b', 'c', 'e'}, 3},
+				{[]byte{'c', 'd', 'e'}, 4},
 			},
 		},
 		{
@@ -59,11 +59,11 @@ func TestTrie(t *testing.T) {
 				4,
 			},
 			expected: []ExpectType{
-				ExpectType{[]byte{'a', 'b', 'c'}, 0},
-				ExpectType{[]byte{'a', 'b', 'c', 'd'}, 1},
-				ExpectType{[]byte{'b', 'c'}, 2},
-				ExpectType{[]byte{'b', 'c', 'd'}, 3},
-				ExpectType{[]byte{'b', 'c', 'd', 'e'}, 4},
+				{[]byte{'a', 'b', 'c'}, 0},
+				{[]byte{'a', 'b', 'c', 'd'}, 1},
+				{[]byte{'b', 'c'}, 2},
+				{[]byte{'b', 'c', 'd'}, 3},
+				{[]byte{'b', 'c', 'd', 'e'}, 4},
 			},
 		},
 	}

--- a/trie/utils.go
+++ b/trie/utils.go
@@ -45,9 +45,9 @@ func (c testKVConv) Marshal(d interface{}) []byte {
 	return b
 }
 
-func (c testKVConv) Unmarshal(b []byte) (uint32, interface{}) {
+func (c testKVConv) Unmarshal(b []byte) (int, interface{}) {
 
-	size := uint32(8)
+	size := 8
 	s := b[:size]
 
 	buf := binary.LittleEndian.Uint64(s)
@@ -61,11 +61,11 @@ func (c testKVConv) Unmarshal(b []byte) (uint32, interface{}) {
 	// addr of *testKV
 	eltP := (*testKV)(covP)
 
-	return uint32(8), eltP
+	return 8, eltP
 }
 
-func (c testKVConv) GetMarshaledSize(b []byte) uint32 {
-	return uint32(8)
+func (c testKVConv) GetMarshaledSize(b []byte) int {
+	return 8
 }
 
 func makeStrings(cnt, leng int64) ([]string, error) {


### PR DESCRIPTION
# Description

- Add doc to `array/converter.go`. Doc format follows `golint` suggestions.

- the 1st return value of `Unmarshal()` is number of bytes consumed. According to interface `io.Reader`, it should be a `int` instead of `uint32`. Short in-memory length should always be `int` type. Large size / offset should be `int64`.

- Other refactoring modification according to `golint`.

## Type of change

- [x] This change requires a documentation update
- [x] Refactoring
- [x] Document changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

