### PR TITLE
array: move out index operation into separate file

### DIFF
--- a/array/compact.go
+++ b/array/compact.go
@@ -4,36 +4,22 @@ package array
 import (
 	"errors"
 	"reflect"
-
-	"github.com/openacid/slim/bit"
-	"github.com/openacid/slim/prototype"
 )
-// ErrIndexLen is returned if number of indexes does not equal the number of
-// datas, when initializing a CompactedArray.
-var ErrIndexLen = errors.New("the length of index and elts must be equal")
 
-// ErrIndexNotAscending means both indexes and datas for initialize a
-// CompactedArray must be in ascending order.
-var ErrIndexNotAscending = errors.New("index must be an ascending slice")
+// ErrIndexLen is returned if number of indexes does not equal the number of
+// datas, when initializing a Array.
+var ErrIndexLen = errors.New("the length of index and elts must be equal")
 
 // Array32 is a space efficient array implementation.
 //
 // Unlike a normal array, it does not allocate space for a element that there is
 // not data in it.
 type Array32 struct {
-	prototype.CompactedArray
+	Array32Index
 	Converter
 }
 
-var bmWidth = uint32(64) // how many bits of an uint64 == 2 ^ 6
-
-func bmBit(idx uint32) (uint32, uint32) {
-	c := idx >> uint32(6) // == idx / bmWidth
-	r := idx & uint32(63) // == idx % bmWidth
-	return c, r
-}
-
-// New32 creates a CompactedArray and initializes it with a slice of index and a
+// New32 creates a Array and initializes it with a slice of index and a
 // slice of data.
 //
 // The index parameter must be a ascending array of type unit32,
@@ -52,21 +38,6 @@ func New32(conv Converter, index []uint32, _elts interface{}) (ca *Array32, err 
 	return ca, nil
 }
 
-func (a *Array32) appendElt(index uint32, elt []byte) {
-	iBm, iBit := bmBit(index)
-
-	var bmWord = &a.Bitmaps[iBm]
-	if *bmWord == 0 {
-		a.Offsets[iBm] = a.Cnt
-	}
-
-	*bmWord |= uint64(1) << iBit
-	a.Elts = append(a.Elts, elt...)
-
-	a.Cnt++
-}
-
-
 // Init initializes a compacted array from the slice type elts
 // the index parameter must be a ascending array of type unit32,
 // otherwise, return the ErrIndexNotAscending error
@@ -83,27 +54,16 @@ func (a *Array32) Init(index []uint32, _elts interface{}) error {
 		return ErrIndexLen
 	}
 
-	capacity := uint32(0)
-	if len(index) > 0 {
-		capacity = index[len(index)-1] + 1
+	err := a.InitIndexBitmap(index)
+	if err != nil {
+		return err
 	}
 
-	bmCnt := (capacity + bmWidth - 1) / bmWidth
-
-	a.Bitmaps = make([]uint64, bmCnt)
-	a.Offsets = make([]uint32, bmCnt)
-	a.Elts = make([]byte, 0, nElts*a.GetMarshaledSize(nil))
-
-	var prevIndex uint32
-	for i := 0; i < len(index); i++ {
-		if i > 0 && index[i] <= prevIndex {
-			return ErrIndexNotAscending
-		}
-
+	a.Elts = make([]byte, 0, nElts)
+	for i := 0; i < nElts; i++ {
 		ee := rElts.Index(i).Interface()
-		a.appendElt(index[i], a.Marshal(ee))
-
-		prevIndex = index[i]
+		raw := a.Marshal(ee)
+		a.Elts = append(a.Elts, raw...)
 	}
 
 	return nil
@@ -118,36 +78,23 @@ func (a *Array32) Get(idx uint32) interface{} {
 // Get2 returns the value indexed by `idx` and a bool indicating existence.
 // If `idx` does not present it returns `nil, false`.
 func (a *Array32) Get2(idx uint32) (interface{}, bool) {
-	iBm, iBit := bmBit(idx)
-
-	if iBm >= uint32(len(a.Bitmaps)) {
-		return nil, false
+	raw, ok := a.GetBytes(idx, a.GetMarshaledSize(nil))
+	if ok {
+		_, val := a.Unmarshal(raw)
+		return val, true
 	}
 
-	var bmWord = a.Bitmaps[iBm]
-
-	if ((bmWord >> iBit) & 1) == 0 {
-		return nil, false
-	}
-
-	base := a.Offsets[iBm]
-	cnt1 := bit.PopCnt64Before(bmWord, iBit)
-
-	stIdx := uint32(a.GetMarshaledSize(nil)) * (base + cnt1)
-
-	_, val := a.Unmarshal(a.Elts[stIdx:])
-	return val, true
+	return nil, false
 }
 
-// Has returns true if idx is in array, else return false
-func (a *Array32) Has(idx uint32) bool {
-	iBm, iBit := bmBit(idx)
-
-	if iBm >= uint32(len(a.Bitmaps)) {
-		return false
+// GetBytes is similar to Get2 but does not return the byte slice instead of
+// unmarshaled data.
+func (a *Array32) GetBytes(idx uint32, eltsize int) ([]byte, bool) {
+	dataIndex, ok := a.GetEltIndex(idx)
+	if !ok {
+		return nil, false
 	}
 
-	var bmWord = a.Bitmaps[iBm]
-
-	return (bmWord>>iBit)&1 > 0
+	stIdx := uint32(eltsize) * dataIndex
+	return a.Elts[stIdx : stIdx+uint32(eltsize)], true
 }

--- a/array/compact.go
+++ b/array/compact.go
@@ -8,6 +8,13 @@ import (
 	"github.com/openacid/slim/bit"
 	"github.com/openacid/slim/prototype"
 )
+// ErrIndexLen is returned if number of indexes does not equal the number of
+// datas, when initializing a CompactedArray.
+var ErrIndexLen = errors.New("the length of index and elts must be equal")
+
+// ErrIndexNotAscending means both indexes and datas for initialize a
+// CompactedArray must be in ascending order.
+var ErrIndexNotAscending = errors.New("index must be an ascending slice")
 
 // Array32 is a space efficient array implementation.
 //
@@ -59,13 +66,6 @@ func (a *Array32) appendElt(index uint32, elt []byte) {
 	a.Cnt++
 }
 
-// ErrIndexLen is returned if number of indexes does not equal the number of
-// datas, when initializing a CompactedArray.
-var ErrIndexLen = errors.New("the length of index and elts must be equal")
-
-// ErrIndexNotAscending means both indexes and datas for initialize a
-// CompactedArray must be in ascending order.
-var ErrIndexNotAscending = errors.New("index must be an ascending slice")
 
 // Init initializes a compacted array from the slice type elts
 // the index parameter must be a ascending array of type unit32,

--- a/array/index.go
+++ b/array/index.go
@@ -1,0 +1,103 @@
+package array
+
+import (
+	"errors"
+
+	"github.com/openacid/slim/bit"
+	"github.com/openacid/slim/prototype"
+)
+
+// Array32Index implements sparsely distributed index with bitmap.
+type Array32Index struct {
+	prototype.CompactedArray
+}
+
+// ErrIndexNotAscending means indexes to initialize a Array must be in
+// ascending order.
+var ErrIndexNotAscending = errors.New("index must be an ascending slice")
+
+// bmWidth defines how many bits for a bitmap word
+var bmWidth = uint32(64)
+
+// bmBit calculates bitamp word index and the bit index in the word.
+func bmBit(idx uint32) (uint32, uint32) {
+	c := idx >> uint32(6) // == idx / bmWidth
+	r := idx & uint32(63) // == idx % bmWidth
+	return c, r
+}
+
+// InitIndexBitmap initializes index bitmap for a compacted array.
+// Index must be a ascending array of type unit32, otherwise, return
+// the ErrIndexNotAscending error
+func (a *Array32Index) InitIndexBitmap(index []uint32) error {
+
+	capacity := uint32(0)
+	if len(index) > 0 {
+		capacity = index[len(index)-1] + 1
+	}
+
+	bmCnt := (capacity + bmWidth - 1) / bmWidth
+
+	a.Bitmaps = make([]uint64, bmCnt)
+	a.Offsets = make([]uint32, bmCnt)
+
+	nxt := uint32(0)
+	for i := 0; i < len(index); i++ {
+		if index[i] < nxt {
+			return ErrIndexNotAscending
+		}
+		a.appendIndex(index[i])
+		nxt = index[i] + 1
+	}
+	return nil
+}
+
+// GetEltIndex returns the data position in a.Elts indexed by `idx` and a bool
+// indicating existence.
+// If `idx` does not present it returns `0, false`.
+func (a *Array32Index) GetEltIndex(idx uint32) (uint32, bool) {
+	iBm, iBit := bmBit(idx)
+
+	if iBm >= uint32(len(a.Bitmaps)) {
+		return 0, false
+	}
+
+	var bmWord = a.Bitmaps[iBm]
+
+	if ((bmWord >> iBit) & 1) == 0 {
+		return 0, false
+	}
+
+	base := a.Offsets[iBm]
+	cnt1 := bit.PopCnt64Before(bmWord, iBit)
+	return base + cnt1, true
+}
+
+// Has returns true if idx is in array, else return false
+func (a *Array32Index) Has(idx uint32) bool {
+	iBm, iBit := bmBit(idx)
+
+	if iBm >= uint32(len(a.Bitmaps)) {
+		return false
+	}
+
+	var bmWord = a.Bitmaps[iBm]
+
+	return (bmWord>>iBit)&1 > 0
+}
+
+// appendIndex add a index into index bitmap.
+// The `index` must be greater than any existent indexes.
+func (a *Array32Index) appendIndex(index uint32) {
+
+	iBm, iBit := bmBit(index)
+
+	var bmWord = &a.Bitmaps[iBm]
+	if *bmWord == 0 {
+		a.Offsets[iBm] = a.Cnt
+	}
+
+	*bmWord |= uint64(1) << iBit
+
+	a.Cnt++
+}


### PR DESCRIPTION
# Description

Array32 has two major function: index operation and user-data operation.
User-data operation is simple. Most of the code is about index bitmap.

Thus I moved out codes about index-bitmap and made it a standalone type.
Hope in future separating index and data would bring convenience to function extending, such as defining new array types that has its own **data** layout, and bitmap optimisation.

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring
- [x] Document changes
- [x] Test changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules