### PR TITLE
trie:index

### DIFF
--- a/trie/index.go
+++ b/trie/index.go
@@ -1,0 +1,67 @@
+package trie
+
+import "github.com/openacid/slim/marshal"
+
+// DataReader defines methods for index data types.
+//
+// A data letting SlimIndex to index it should implement this interface.
+type DataReader interface {
+	// Read value at offset, of `key`.
+	// Because SlimIndex does not store complete info of a key(to reduce memory
+	// consumption).
+	// Thus the offset SlimIndex returns might not be correct for a abscent key.
+	// It is data providers' responsibility to check if the record at `offset`
+	// has the exact `key`.
+	Read(offset int64, key string) (string, bool)
+}
+
+// OffsetIndexItem defines data types for a offset-based index, such as an index
+// of on-disk records.
+type OffsetIndexItem struct {
+	// Key is the item identifier to identify a record.
+	Key string
+	// Offset is the position of this record in some data storage, E.g. the
+	// offset in a file where this record is stored.
+	Offset int64
+}
+
+// SlimIndex provides a commonly used index structure, it contains an SlimTrie
+// instance as index and data provider `DataReader`.
+type SlimIndex struct {
+	SlimTrie
+	DataReader
+}
+
+// NewSlimIndex provides a handy index implmentation.
+//
+// It creates a memory efficient index with SlimTrie.
+func NewSlimIndex(index []OffsetIndexItem, dr DataReader) (*SlimIndex, error) {
+
+	l := len(index)
+	keys := make([]string, 0, l)
+	offsets := make([]int64, 0, l)
+	for i := 0; i < l; i++ {
+		keys = append(keys, index[i].Key)
+		offsets = append(offsets, index[i].Offset)
+	}
+
+	st, err := NewSlimTrie(marshal.I64{}, keys, offsets)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SlimIndex{*st, dr}, nil
+}
+
+// Get returns the value of `key` which is found in `SlimIndex.DataReader`, and
+// a bool value indicate if the `key` is found or not.
+func (si *SlimIndex) Get(key string) (string, bool) {
+	o := si.SlimTrie.Get(key)
+	if o == nil {
+		return "", false
+	}
+
+	offset := o.(int64)
+
+	return si.DataReader.Read(offset, key)
+}

--- a/trie/index_test.go
+++ b/trie/index_test.go
@@ -1,0 +1,67 @@
+package trie_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openacid/slim/trie"
+)
+
+type testIndexData string
+
+func (d testIndexData) Read(offset int64, key string) (string, bool) {
+	kv := strings.Split(string(d)[offset:], ",")[0:2]
+	if kv[0] == key {
+		return kv[1], true
+	}
+	return "", false
+}
+
+func TestSlimIndex(t *testing.T) {
+
+	data := testIndexData("Aaron,1,Agatha,1,Al,2,Albert,3,Alexander,5,Alison,8")
+
+	index := []trie.OffsetIndexItem{
+		{Key: "Aaron", Offset: 0},
+		{Key: "Agatha", Offset: 8},
+		{Key: "Al", Offset: 17},
+		{Key: "Albert", Offset: 22},
+		{Key: "Alexander", Offset: 31},
+		{Key: "Alison", Offset: 43},
+	}
+
+	st, err := trie.NewSlimIndex(index, data)
+	if err != nil {
+		t.Fatalf("expect no error but: %s", err)
+	}
+
+	cases := []struct {
+		input     string
+		want      string
+		wantfound bool
+	}{
+		{"Aaron", "1", true},
+		{"Agatha", "1", true},
+		{"Al", "2", true},
+		{"Albert", "3", true},
+		{"Alexander", "5", true},
+		{"Alison", "8", true},
+		{"foo", "", false},
+		{"Alexande", "", false},
+		{"Alexander0", "", false},
+		{"alexander", "", false},
+	}
+
+	for i, c := range cases {
+		rst, found := st.Get(c.input)
+		if rst != c.want {
+			t.Fatalf("%d-th: input: %v; want: %v; actual: %v",
+				i+1, c.input, c.want, rst)
+		}
+		if found != c.wantfound {
+			t.Fatalf("%d-th: input: %v; wantfound: %v; actual: %v",
+				i+1, c.input, c.wantfound, found)
+		}
+	}
+
+}


### PR DESCRIPTION
SlimIndex provides a handy API for most common usages.
One of the most common case is to use SlimTrie to index on-disk data.

A SlimIndex instance contains a SlimTrie index and a user defined
DataReader which is used to load data from storage, such as from a file.

SlimIndex is introduced to make it easier to use for end user.

The example of how to use SlimIndex is coming in next PR.
A common usage is as following:

```go
type Data string

func (d Data) Read(offset int64, key string) (string, bool) {
	kv := strings.Split(string(d)[offset:], ",")[0:2]
	if kv[0] == key {
		return kv[1], true
	}
	return "", false
}

func Example() {
	data := Data("Aaron,1,Agatha,1,Al,2,Albert,3,Alexander,5,Alison,8")

	// `index` is a prebuilt index of a key and its offset in `data`.
	index := []trie.OffsetIndexItem{
		{"Aaron", 0},
		{"Agatha", 8},
		{"Al", 17},
		{"Albert", 22},
		{"Alexander", 31},
		{"Alison", 43},
	}

	st, err := trie.NewSlimIndex(index, data)
	if err != nil {
		fmt.Println(err)
	}

	v, found := st.Get("Alison")
	fmt.Printf("key: %q\n  found: %t\n  value: %q\n", "Alison", found, v)

	v, found = st.Get("foo")
	fmt.Printf("key: %q\n  found: %t\n  value: %q\n", "foo", found, v)

}

```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

