### PR TITLE
Slimtrie range get

### DIFF
--- a/trie/example_slimtrie_range_test.go
+++ b/trie/example_slimtrie_range_test.go
@@ -1,0 +1,88 @@
+package trie
+
+import (
+	"fmt"
+
+	"github.com/openacid/slim/encode"
+)
+
+func ExampleSlimTrie_RangeGet() {
+
+	// To index a map of key range to value with SlimTrie is very simple:
+	//
+	// Just give two adjacent keys the same value, then SlimTrie knows these
+	// keys belong to a "range".
+	// These two keys are left and right boundaries of a range, and are both
+	// inclusive.
+	//
+	// In this example we:
+	//
+	//   map [abc, abcd] to 1
+	//   map [bc, bc]    to 2 // this range has only one key in it.
+	//   map [bcd, bce]  to 3
+	//
+	// With RangeGet() to get any key that "abc" <= key <= "abcd", such as
+	// "abc1", "abc2"... should return "1".
+	//
+	// False Positive
+	//
+	// Just like Bloomfilter, SlimTrie does not contains full information of keys,
+	// thus there could be a false positive return:
+	// It returns some value and "true" but the key is not in there.
+
+	keys := []string{
+		"abc", "abcd",
+		"bc",
+		"bcd", "bce",
+	}
+	values := []int{
+		1, 1,
+		2,
+		3, 3,
+	}
+	st, err := NewSlimTrie(encode.Int{}, keys, values)
+	if err != nil {
+		panic(err)
+	}
+
+	cases := []struct {
+		key string
+		msg string
+	}{
+		{"ab", "smaller than any"},
+
+		{"abc", "in range [abc, abcd]"},
+		{"abc1", "in range [abc, abcd]"},
+		{"abc2", "in range [abc, abcd]"},
+		{"abcd", "in range [abc, abcd]"},
+
+		{"abcde", "not in any range"},
+
+		{"acc", "FALSE POSITIVE: not in range [abc, abcd]"},
+
+		{"bc", "in single key range [bc]"},
+		{"bc1", "not in single key range [bc]"},
+
+		{"bcd1", "in range [bcd, bce]"},
+
+		{"def", "greater than any"},
+	}
+
+	for _, c := range cases {
+		v, found := st.RangeGet(c.key)
+		fmt.Printf("%-10s %-5v %-5t: %s\n", c.key, v, found, c.msg)
+	}
+
+	// Output:
+	// ab         <nil> false: smaller than any
+	// abc        1     true : in range [abc, abcd]
+	// abc1       1     true : in range [abc, abcd]
+	// abc2       1     true : in range [abc, abcd]
+	// abcd       1     true : in range [abc, abcd]
+	// abcde      <nil> false: not in any range
+	// acc        1     true : FALSE POSITIVE: not in range [abc, abcd]
+	// bc         2     true : in single key range [bc]
+	// bc1        <nil> false: not in single key range [bc]
+	// bcd1       3     true : in range [bcd, bce]
+	// def        <nil> false: greater than any
+}

--- a/trie/slimtrie.go
+++ b/trie/slimtrie.go
@@ -202,7 +202,29 @@ func (st *SlimTrie) LoadTrie(root *Node) (err error) {
 // A non-nil return value does not mean the `key` exists.
 // An in-existent `key` also could matches partial info stored in SlimTrie.
 func (st *SlimTrie) Search(key string) (lVal, eqVal, rVal interface{}) {
-	eqID, lID, rID := int32(0), int32(-1), int32(-1)
+
+	lID, eqID, rID := st.searchID(key)
+
+	if lID != -1 {
+		lVal, _ = st.Leaves.Get(lID)
+	}
+	if eqID != -1 {
+		eqVal, _ = st.Leaves.Get(eqID)
+	}
+	if rID != -1 {
+		rVal, _ = st.Leaves.Get(rID)
+	}
+
+	return
+}
+
+// searchID searches for key and returns 3 leaf node id:
+//
+// The id of greatest key < `key`. It is -1 if `key` is the smallest.
+// The id of `key`. It is -1 if there is not a matching.
+// The id of smallest key > `key`. It is -1 if `key` is the greatest.
+func (st *SlimTrie) searchID(key string) (lID, eqID, rID int32) {
+	lID, eqID, rID = -1, 0, -1
 	lIsLeaf := false
 
 	// string to 4-bit words
@@ -267,14 +289,9 @@ func (st *SlimTrie) Search(key string) (lVal, eqVal, rVal interface{}) {
 		if !lIsLeaf {
 			lID = int32(st.rightMost(uint16(lID)))
 		}
-		lVal, _ = st.Leaves.Get(lID)
 	}
 	if rID != -1 {
 		rID = int32(st.leftMost(uint16(rID)))
-		rVal, _ = st.Leaves.Get(rID)
-	}
-	if eqID != -1 {
-		eqVal, _ = st.Leaves.Get(eqID)
 	}
 
 	return

--- a/trie/slimtrie_test.go
+++ b/trie/slimtrie_test.go
@@ -422,6 +422,66 @@ func TestSquashedSearch(t *testing.T) {
 	}
 }
 
+func TestRangeGet(t *testing.T) {
+
+	keys := []string{
+		"abc",
+		"abcd",
+
+		"abd",
+		"abde",
+
+		"bc",
+
+		"bcd",
+		"bce",
+
+		"cde",
+	}
+	values := []int{
+		0, 0,
+		1, 1,
+		2,
+		3, 3,
+		4,
+	}
+	searches := []struct {
+		key       string
+		want      interface{}
+		wantfound bool
+	}{
+		{"ab", nil, false},
+		{"abc", 0, true},
+		{"abcde", nil, false},
+		{"abd", 1, true},
+		{"ac", nil, false},
+		{"acb", nil, false},
+		{"acd", 1, true}, // false positive
+		{"adc", 0, true}, // false positive
+		{"bcd", 3, true},
+		{"bce", 3, true},
+		{"c", nil, false},
+		{"cde", 4, true},
+		{"cfe", 4, true},    // false positive
+		{"cff", 4, true},    // false positive
+		{"def", nil, false}, // false positive
+	}
+
+	st, err := NewSlimTrie(encode.Int{}, keys, values)
+	if err != nil {
+		t.Fatalf("expected no error but: %+v", err)
+	}
+	for i, c := range searches {
+		rst, found := st.RangeGet(c.key)
+		if c.want != rst {
+			t.Fatalf("%d-th key: %s expect: %v; but: %v", i+1, c.key, c.want, rst)
+		}
+		if c.wantfound != found {
+			t.Fatalf("%d-th key: %s expect: %v; but: %v", i+1, c.key, c.wantfound, found)
+		}
+	}
+}
+
 func TestNewSlimTrie(t *testing.T) {
 
 	st, err := NewSlimTrie(encode.Int{}, []string{"ab", "cd"}, []int{1, 2})


### PR DESCRIPTION
# To support key range to value map.

To index a map of key range to value with SlimTrie is very simple:

Just give two adjacent keys the same value, then SlimTrie knows these
keys belong to a "range".
These two keys are left and right boundaries of a range, and are both
inclusive.

```
  map [abc, abcd] to 1
  map [bc, bc]    to 2 // this range has only one key in it.
  map [bcd, bce]  to 3
```

With RangeGet() to get any key that `"abc" <= key <= "abcd"`, such as
"abc1", "abc2"... should return "1".

**False Positive**

Just like Bloomfilter, SlimTrie does not contains full information of keys,
thus there could be a false positive return:
It returns some value and "true" but the key is not in there.

Usage:
```go
keys := []string{
    "abc", "abcd",
    "bc",
    "bcd", "bce",
}
values := []int{
    1, 1,
    2,
    3, 3,
}
st, err := NewSlimTrie(encode.Int{}, keys, values)
if err != nil {
    panic(err)
}

cases := []struct {
    key string
    msg string
}{
    {"ab", "smaller than any"},

    {"abc", "in range [abc, abcd]"},
    {"abc1", "in range [abc, abcd]"},
    {"abc2", "in range [abc, abcd]"},
    {"abcd", "in range [abc, abcd]"},

    {"abcde", "not in any range"},

    {"acc", "FALSE POSITIVE: not in range [abc, abcd]"},

    {"bc", "in single key range [bc]"},
    {"bc1", "not in single key range [bc]"},

    {"bcd1", "in range [bcd, bce]"},

    {"def", "greater than any"},
}

for _, c := range cases {
    v, found := st.RangeGet(c.key)
    fmt.Printf("%-10s %-5v %-5t: %s\n", c.key, v, found, c.msg)
}
```

Output:

```
ab         <nil> false: smaller than any
abc        1     true : in range [abc, abcd]
abc1       1     true : in range [abc, abcd]
abc2       1     true : in range [abc, abcd]
abcd       1     true : in range [abc, abcd]
abcde      <nil> false: not in any range
acc        1     true : FALSE POSITIVE: not in range [abc, abcd]
bc         2     true : in single key range [bc]
bc1        <nil> false: not in single key range [bc]
bcd1       3     true : in range [bcd, bce]
def        <nil> false: greater than any
```

Fixes #81 

## Type of change

- **New feature**     <!-- non-breaking change which adds functionality -->
- **Refactoring**
- **Document changes**
- **Test changes**


# Checklist:

- [x] **Style**:       My code follows the **style guidelines** of this project
- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
- [ ] **Dep**:         Any **dependent** changes have been merged and published in downstream modules
