### PR TITLE
new-feature: slimtrie: max key limit extends to 2^31

### DIFF
--- a/trie/errors.go
+++ b/trie/errors.go
@@ -5,7 +5,7 @@ import "github.com/openacid/errors"
 var (
 	// ErrTooManyTrieNodes indicates the number of trie nodes(not number of
 	// keys) exceeded.
-	ErrTooManyTrieNodes = errors.New("exceeds max node count=65536")
+	ErrTooManyTrieNodes = errors.New("exceeds max node count=2^31-1")
 
 	// ErrTrieBranchValueOverflow indicate input key consists of a word greater
 	// than the max 4-bit word(0x0f).

--- a/trie/slimtrie.go
+++ b/trie/slimtrie.go
@@ -43,8 +43,8 @@ const (
 	WordMask = 0xf
 	// LeafWord is a special value to indicate a leaf node in a Trie.
 	LeafWord = byte(0x10)
-	// MaxNodeCnt is the max number of node(including leaf and inner node).
-	MaxNodeCnt = 65536
+	// MaxNodeCnt is the max number of node. Node id in SlimTrie is int32.
+	MaxNodeCnt = (1 << 31) - 1
 )
 
 // SlimTrie is a space efficient Trie index.


### PR DESCRIPTION
# Description

new-feature: slimtrie: max key limit extends to 2^31

## Type of change

<!-- Please delete options that are not relevant. -->

- **New feature**     <!-- non-breaking change which adds functionality -->

# Checklist:

- [x] **Style**:       My code follows the **style guidelines** of this project
- [x] **Self-review**: I have performed a **self-review** of my own code
- [x] **Comment**:     I have **commented my code**, particularly in hard-to-understand areas
- [x] **Doc**:         I have made corresponding changes to the **documentation**
- [x] **No-warnings**: My changes generate **no new warnings**
- [x] **Add-test**:    I have added **tests** that prove my fix is effective or that my feature works
- [x] **Pass**:        New and existing **unit tests pass** locally with my changes
- [ ] **Dep**:         Any **dependent** changes have been merged and published in downstream modules
