### PR TITLE
Add scanning API

### DIFF
--- a/trie/example_scan_test.go
+++ b/trie/example_scan_test.go
@@ -1,0 +1,80 @@
+package trie
+
+import (
+	"fmt"
+
+	"github.com/openacid/slim/encode"
+)
+
+func ExampleSlimTrie_ScanFrom() {
+	var keys = []string{
+		"",
+		"`",
+		"a",
+		"ab",
+		"abc",
+		"abca",
+		"abcd",
+		"abcd1",
+		"abce",
+		"be",
+		"c",
+		"cde0",
+		"d",
+	}
+	values := makeI32s(len(keys))
+
+	codec := encode.I32{}
+	st, _ := NewSlimTrie(codec, keys, values, Opt{
+		Complete: Bool(true),
+	})
+
+	// untilD stops when encountering "d".
+	untilD := func(k, v []byte) bool {
+		if string(k) == "d" {
+			return false
+		}
+
+		_, i32 := codec.Decode(v)
+		fmt.Println(string(k), i32)
+		return true
+	}
+
+	fmt.Println("scan (ab, +∞):")
+	st.ScanFrom("ab", false, true, untilD)
+
+	fmt.Println()
+	fmt.Println("scan [be, +∞):")
+	st.ScanFrom("be", true, true, untilD)
+
+	fmt.Println()
+	fmt.Println("scan (ab, be):")
+	st.ScanFromTo(
+		"ab", false,
+		"be", false,
+		true, untilD)
+
+	// Output:
+	//
+	// scan (ab, +∞):
+	// abc 4
+	// abca 5
+	// abcd 6
+	// abcd1 7
+	// abce 8
+	// be 9
+	// c 10
+	// cde0 11
+	//
+	// scan [be, +∞):
+	// be 9
+	// c 10
+	// cde0 11
+	//
+	// scan (ab, be):
+	// abc 4
+	// abca 5
+	// abcd 6
+	// abcd1 7
+	// abce 8
+}

--- a/trie/slimtrie_query.go
+++ b/trie/slimtrie_query.go
@@ -326,25 +326,28 @@ func (st *SlimTrie) searchID(key string) (lID, eqID, rID int32) {
 		lID = st.rightMost(lID)
 	}
 	if rID != -1 {
-		rID = st.leftMost(rID)
+		rID = st.leftMost(rID, nil)
 	}
 
 	return
 }
 
-func (st *SlimTrie) leftMost(idx int32) int32 {
+func (st *SlimTrie) leftMost(idx int32, path *[]int32) int32 {
 
 	ns := st.inner
+	qr := &querySession{}
 
 	for {
-
-		qr := &querySession{}
+		if path != nil {
+			*path = append(*path, idx)
+		}
 
 		st.getNode(idx, qr)
 		if qr.isInner == 0 {
 			break
 		}
 
+		// follow the first child
 		r0, _ := bitmap.Rank128(ns.Inners.Words, ns.Inners.RankIndex, qr.from)
 		idx = r0 + 1
 	}

--- a/trie/slimtrie_query.go
+++ b/trie/slimtrie_query.go
@@ -560,6 +560,21 @@ func (st *SlimTrie) getIthLeaf(ith int32) interface{} {
 	return v
 }
 
+func (st *SlimTrie) getIthLeafBytes(ith int32) []byte {
+
+	ls := st.inner.Leaves
+	if ls == nil {
+		return nil
+	}
+
+	// TODO use FixedSize or bitmap for var-len leaves
+	// TODO it is possible there is a absent leaf
+	size := st.encoder.GetEncodedSize(nil)
+	idx := ith * int32(size)
+
+	return ls.Bytes[idx : idx+int32(size)]
+}
+
 func (st *SlimTrie) getLabels(qr *querySession) []uint64 {
 	bm, _ := st.getInnerBM(qr)
 	return bmtree.Decode(qr.to-qr.from, bm)

--- a/trie/slimtrie_scan.go
+++ b/trie/slimtrie_scan.go
@@ -1,0 +1,426 @@
+package trie
+
+import (
+	"bytes"
+
+	"github.com/openacid/low/bitmap"
+)
+
+// NextRaw returns next key-value pair in []byte.
+type NextRaw func() ([]byte, []byte)
+
+// WalkFn is used when walking the slimtrie. Takes a
+// key and value, returning false if iteration should
+// be terminated.
+//
+// If withValue is false when calling NewIter(), value is always nil.
+//
+// Since 0.5.11
+type WalkFn func(key []byte, value []byte) bool
+
+// ScanFrom iterates key-values in the slimtrie and pass every key-value pair to
+// a callback function fn.
+//
+// The iteration starts from `start`, including the
+// starting key if includeStart is true.
+// The key and value it passes to fn are temporary slice []byte, i.e., next time calling
+// fn, the previously returned slice will be invalid.
+//
+// If withValue is false, the value passed to fn is always nil.
+//
+// ScanFrom requires a full slimtrie to work, i.e., created with NewSlimTrie(... Opt{Complete: Bool(true)}).
+//
+// Since 0.5.11
+func (st *SlimTrie) ScanFrom(
+	start string, includeStart bool,
+	withValue bool, fn WalkFn) {
+
+	startPath, startEqual := st.getGEPath(start)
+	nxt := st.newIter(startPath, startEqual && !includeStart, withValue)
+
+	for {
+		key, value := nxt()
+		if key == nil {
+			break
+		}
+
+		if !fn(key, value) {
+			break
+		}
+	}
+}
+
+// ScanFromTo is similar to ScanFrom except it accepts an additional ending boundary (end, includeEnd)
+//
+// Since 0.5.11
+func (st *SlimTrie) ScanFromTo(
+	start string, includeStart bool,
+	end string, includeEnd bool,
+	withValue bool, fn WalkFn) {
+
+	e := []byte(end)
+
+	st.ScanFrom(start, includeStart, withValue, func(k, v []byte) bool {
+
+		// stop the scanning if it reaches the ending boundary.
+		r := bytes.Compare(k, e)
+		if r == 0 && !includeEnd || r > 0 {
+			return false
+		}
+
+		return fn(k, v)
+	})
+}
+
+// NewIter is a low level scanning API and gives users more control over
+// the iteration.
+// It scans from the specified key and returns a function `next()` that yields
+// next key and value every time it is called.
+// The `next()` returns nil after all keys yield.
+// The key and value it yields is a temporary slice []byte, i.e., next time calling
+// the `next()`, the previously returned slice will be invalid.
+//
+// NewIter requires a full slimtrie to work, i.e., created with NewSlimTrie(... Opt{Complete: Bool(true)}).
+//
+// Since 0.5.11
+func (st *SlimTrie) NewIter(start string, includeStart bool,
+	withValue bool) NextRaw {
+
+	startPath, startEqual := st.getGEPath(start)
+	return st.newIter(startPath, startEqual && !includeStart, withValue)
+}
+
+func (st *SlimTrie) newIter(path []int32, skipFirst, withValue bool) NextRaw {
+
+	buf := make([]byte, 0, 64)
+	bufBitIdx := int32(0)
+	stack := make([]scanStackElt, len(path)*2)
+	stackIdx := -1
+	for i := int32(0); i < int32(len(path)-1); i++ {
+
+		qr := &querySession{}
+		st.getNode(path[i], qr)
+
+		stackIdx++
+		v := &stack[stackIdx]
+		v.init(st, path[i], path[i+1], qr, bufBitIdx)
+		v.appendInnerPrefix(&buf, qr)
+
+		// NOTE: the first time executing next(), the last label will always be overridden.
+		v.appendLabel(&buf)
+		bufBitIdx = v.labelEnd
+	}
+
+	if skipFirst {
+		stackIdx = next(stack, stackIdx)
+	}
+
+	return func() ([]byte, []byte) {
+
+		if stackIdx == -1 {
+			return nil, nil
+		}
+
+		var val []byte
+
+		// walk to a leaf and fill in the buf
+		for {
+			last := &stack[stackIdx]
+			last.appendLabel(&buf)
+
+			childId := last.firstChildId + last.ithLabel
+			qr := &querySession{}
+			st.getNode(childId, qr)
+			if qr.isInner == 0 {
+				last.appendLeafPrefix(&buf, qr)
+				if withValue {
+					leafI, _ := st.getLeafIndex(childId)
+					val = st.getIthLeafBytes(leafI)
+				}
+				break
+			}
+
+			stackIdx++
+			if stackIdx == len(stack) {
+				stack = append(stack, scanStackElt{})
+			}
+			elt := &stack[stackIdx]
+			elt.init(st, childId, -1, qr, last.labelEnd)
+			elt.appendInnerPrefix(&buf, qr)
+		}
+
+		// remove leaf from the stack and walk to next.
+		stackIdx = next(stack, stackIdx)
+		return buf, val
+	}
+}
+
+// next moves cursor to the next available label and returns the index of the
+// entry in stack that has a next entry.
+func next(stack []scanStackElt, stackIdx int) int {
+	for stackIdx >= 0 {
+		last := &stack[stackIdx]
+		labelSz := last.nextLabel(1)
+		if labelSz != -1 {
+			break
+		}
+		stackIdx--
+	}
+	return stackIdx
+}
+
+// getGEPath finds the node path in the trie from root to a leaf, that represents a string >= key
+// It returns a node path and a bool indicating if the path exactly equals to
+// the searching key.
+func (st *SlimTrie) getGEPath(key string) ([]int32, bool) {
+
+	if st.inner.NodeTypeBM == nil {
+		return []int32{}, false
+	}
+
+	if st.inner.InnerPrefixes == nil || st.inner.LeafPrefixes == nil {
+		panic("incomplete slim does not support scanning. requires InnerPrefixes and LeafPrefixes")
+	}
+
+	eqID := int32(0)
+	// the smallest child id ever seen that is greater than key.
+	rID := int32(-1)
+	// the length of the right side path.
+	rightPathLen := int32(-1)
+	l := int32(8 * len(key))
+	path := make([]int32, 0)
+	ns := st.inner
+
+	qr := &querySession{
+		keyBitLen: l,
+		key:       key,
+	}
+
+	i := int32(0)
+
+	for {
+
+		st.getNode(eqID, qr)
+		if qr.isInner == 0 {
+			// leaf
+			break
+		}
+
+		if qr.hasInnerPrefix {
+			r := prefixCompare(key[i>>3:], qr.innerPrefix)
+			if r == 0 {
+				i = i&(^7) + qr.innerPrefixLen
+			} else if r < 0 {
+				rID = eqID
+				rightPathLen = int32(len(path))
+				eqID = -1
+				break
+			} else {
+				// choose the next smallest path
+				eqID = -1
+				break
+			}
+		}
+
+		path = append(path, eqID)
+
+		leftChild, has := st.getLeftChildID(qr, i)
+		chID := leftChild + has
+		rightChild := chID + 1
+
+		rightMostChild, bit := bitmap.Rank128(ns.Inners.Words, ns.Inners.RankIndex, qr.to-1)
+		rightMostChild += bit
+
+		if rightChild <= rightMostChild {
+			rID = rightChild
+			rightPathLen = int32(len(path))
+		}
+
+		if has == 0 {
+			eqID = -1
+			break
+		}
+		eqID = chID
+
+		// quick path: leaf has no prefix. qr.wordSize is 0. matches the 0-th bit
+		if i == l {
+			// must be a leaf
+			break
+		}
+
+		i += qr.wordSize
+	}
+
+	if eqID != -1 {
+		tail := key[i>>3:]
+		r := st.cmpLeafPrefix(tail, qr)
+		if r <= 0 {
+			path = append(path, eqID)
+			return path, r == 0
+		}
+	}
+
+	if rID == -1 {
+		return []int32{}, false
+	}
+
+	// discard the exact-match part, choose the next smallest path
+	path = path[:rightPathLen]
+	st.leftMost(rID, &path)
+
+	return path, false
+}
+
+// scanStackElt represents the recursion state of a node.
+type scanStackElt struct {
+	st           *SlimTrie
+	nodeId       int32
+	firstChildId int32
+	ithLabel     int32
+
+	// labelBit is the index of the label in a inner node bitmap
+	labelBit int32
+
+	// labelWidth is 0, 4 or 8
+	labelWidth int32
+	// label is a 0-bit, 4-bit or 8-bit word
+	label int32
+
+	// bit range of this inner node.
+	bitFrom, bitTo int32
+	// If it is a short bitmap, cache it.
+	bm uint64
+
+	// The buffer is in form of <prefix><label><prefix><label>... these 3 fields are bit index in the buf.
+	prefixStart int32
+	prefixEnd   int32
+	labelEnd    int32
+}
+
+func (v *scanStackElt) init(st *SlimTrie, parentId, childId int32, qr *querySession, bufBitIdx int32) {
+
+	ns := st.inner
+	prefStart := bufBitIdx
+	prefEnd := prefStart
+	if qr.hasInnerPrefix {
+		prefEnd = bufBitIdx&(^7) + qr.innerPrefixLen
+	}
+
+	// childId = rank_inclusive(globalLabelBitIdx)
+	//         = rank_exclusive(qr.from) + ithBit + 1
+	// ithBit = childId - 1 - rank_exclusive(qr.from)
+	rnk, _ := bitmap.Rank128(ns.Inners.Words, ns.Inners.RankIndex, qr.from)
+	firstChildId := rnk + 1
+
+	labelIdx := childId - firstChildId
+	// childId=-1 to find the first childId
+	if childId == -1 {
+		labelIdx = 0
+	}
+
+	v.st = st
+	v.nodeId = parentId
+	v.firstChildId = firstChildId
+	v.ithLabel = labelIdx - 1
+	v.bitFrom = qr.from
+	v.bitTo = qr.to
+	v.bm = 0
+	v.labelBit = -1
+	v.labelWidth = -1
+	v.label = -1
+	v.prefixStart = prefStart
+	v.prefixEnd = prefEnd
+
+	if v.bitTo-v.bitFrom == ns.ShortSize {
+		v.bm = qr.bm
+	}
+
+	v.nextLabel(labelIdx + 1)
+}
+
+func (v *scanStackElt) nextLabelBit(n int32) int32 {
+	for n > 0 {
+		v.labelBit++
+		if v.bm != 0 {
+			if v.labelBit == 17 {
+				return -1
+			}
+			if v.bm&bitmap.Bit[v.labelBit] != 0 {
+				n--
+			}
+		} else {
+			if v.labelBit == v.bitTo-v.bitFrom {
+				return -1
+			}
+			i := v.bitFrom + v.labelBit
+			if v.st.inner.Inners.Words[i>>6]&bitmap.Bit[i&63] != 0 {
+				n--
+			}
+		}
+	}
+	return v.labelBit
+}
+
+// move cursor to next label
+func (v *scanStackElt) nextLabel(n int32) int32 {
+	v.ithLabel++
+
+	labelBit := v.nextLabelBit(n)
+	if labelBit == -1 {
+		return -1
+	}
+	v.updateLabel()
+	return v.labelWidth
+}
+
+// update the size and label
+func (v *scanStackElt) updateLabel() {
+	if v.labelBit == 0 {
+		v.labelWidth, v.label = 0, 0
+	} else if v.bm != 0 {
+		// short bitmap is alias of 17 bit bitmap
+		v.labelWidth, v.label = 4, v.labelBit-1
+	} else {
+
+		size := v.bitTo - v.bitFrom
+		if size == 17 {
+			v.labelWidth, v.label = 4, v.labelBit-1
+		} else if size == 257 {
+			v.labelWidth, v.label = 8, v.labelBit-1
+		} else {
+			panic("unknown bitmap size")
+		}
+	}
+	v.labelEnd = v.prefixEnd + v.labelWidth
+}
+
+func (v *scanStackElt) appendLabel(buf *[]byte) {
+
+	labelSize := v.labelWidth
+	l := (v.prefixEnd + 7) >> 3
+	*buf = (*buf)[:l]
+
+	mask := byte(bitmap.Mask[labelSize])
+	if labelSize > 0 {
+		if v.prefixEnd&7 != 0 {
+			c := (*buf)[l-1]
+			(*buf)[l-1] = c&(^mask) | (byte(v.label) & mask)
+		} else {
+			b := byte(v.label) & mask
+			*buf = append(*buf, b<<uint32(8-labelSize))
+		}
+	}
+}
+
+func (v *scanStackElt) appendInnerPrefix(buf *[]byte, qr *querySession) {
+	if qr.hasInnerPrefix {
+		*buf = append((*buf)[:v.prefixStart>>3], qr.innerPrefix[1:]...)
+	}
+}
+
+func (v *scanStackElt) appendLeafPrefix(buf *[]byte, qr *querySession) {
+	*buf = (*buf)[:v.labelEnd>>3]
+	if qr.hasLeafPrefix {
+		*buf = append(*buf, qr.leafPrefix...)
+	}
+}

--- a/trie/slimtrie_scan_test.go
+++ b/trie/slimtrie_scan_test.go
@@ -1,0 +1,392 @@
+package trie
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/openacid/slim/encode"
+	"github.com/stretchr/testify/require"
+)
+
+var defaultScan = []string{
+	"",
+	"`",
+	"a",
+	"ab",
+	"abc",
+	"abca",
+	"abcd",
+	"abcd1",
+	"abce",
+	"be",
+	"c",
+	"cde0",
+	"d",
+}
+var iterCases = map[string]struct {
+	keys         []string
+	slimStr      string
+	paths        [][]int32
+	scanFromKeys []string
+}{
+	"empty": {
+		keys:         []string{},
+		slimStr:      trim(""),
+		paths:        [][]int32{{}},
+		scanFromKeys: defaultScan,
+	},
+	"simple": {
+		keys: []string{
+			"abc",
+			"abcd",
+			"abd",
+			"abde",
+			"bc",
+			"bcd",
+			"bcde",
+			"cde",
+		},
+		slimStr: trim(`
+#000+4*3
+    -0001->#001+12*2
+               -0011->#004*2
+                          -->#008=0
+                          -0110->#009=1
+               -0100->#005*2
+                          -->#010=2
+                          -0110->#011=3
+    -0010->#002+8*2
+               -->#006=4
+               -0110->#007+8*2
+                          -->#012=5
+                          -0110->#013=6
+    -0011->#003=7
+`),
+		paths: [][]int32{
+			{0, 1, 4, 8},
+			{0, 1, 4, 9},
+			{0, 1, 5, 10},
+			{0, 1, 5, 11},
+			{0, 2, 6},
+			{0, 2, 7, 12},
+			{0, 2, 7, 13},
+			{0, 3},
+			{}, // path seeking from after the last key
+		},
+		scanFromKeys: defaultScan,
+	},
+	"emptyKey": {
+		keys: []string{
+			"",
+			"a",
+			"abc",
+			"abd",
+			"bc",
+			"bcd",
+			"cde",
+		},
+		slimStr: trim(`
+#000*2
+    -->#001=0
+    -0110->#002*3
+               -0001->#003*2
+                          -->#006=1
+                          -0110->#007+12*2
+                                     -0011->#010=2
+                                     -0100->#011=3
+               -0010->#004+8*2
+                          -->#008=4
+                          -0110->#009=5
+               -0011->#005=6
+`),
+		paths: [][]int32{
+			{0, 1},
+			{0, 2, 3, 6},
+			{0, 2, 3, 7, 10},
+			{0, 2, 3, 7, 11},
+			{0, 2, 4, 8},
+			{0, 2, 4, 9},
+			{0, 2, 5},
+			{}, // path seeking from after the last key
+		},
+		scanFromKeys: defaultScan,
+	},
+}
+
+func TestSlimTrie_Iter(t *testing.T) {
+
+	for name, c := range iterCases {
+		t.Run(name, func(t *testing.T) {
+
+			ta := require.New(t)
+
+			values := makeI32s(len(c.keys))
+
+			st, err := NewSlimTrie(encode.I32{}, c.keys, values, Opt{Complete: Bool(true)})
+			ta.NoError(err)
+
+			dd(st)
+			ta.Equal(c.slimStr, st.String())
+
+			subTestPath(t, st, c.keys, c.paths, c.keys)
+			subTestPath(t, st, c.keys, c.paths, c.scanFromKeys)
+			subTestIter(t, st, c.keys, c.keys)
+			subTestIter(t, st, c.keys, c.scanFromKeys)
+			subTestIter(t, st, c.keys, randVStrings(len(c.keys)*5, 0, 10))
+
+			subTestScan(t, st, c.keys, c.keys)
+			subTestScan(t, st, c.keys, c.scanFromKeys)
+			subTestScan(t, st, c.keys, randVStrings(len(c.keys)*5, 0, 10))
+		})
+	}
+}
+
+func TestSlimTrie_NewIter_panic(t *testing.T) {
+
+	ta := require.New(t)
+	keys := iterCases["simple"].keys
+	values := makeI32s(len(keys))
+
+	ta.Panics(func() {
+		st, err := NewSlimTrie(encode.I32{}, keys, values, Opt{InnerPrefix: Bool(true)})
+		ta.NoError(err)
+		st.NewIter("abc", true, true)
+	}, "without leaf prefix")
+
+	ta.Panics(func() {
+		st, err := NewSlimTrie(encode.I32{}, keys, values)
+		ta.NoError(err)
+		st.NewIter("abc", true, true)
+	}, "without inner prefix")
+}
+
+func TestSlimTrie_NewIter_slimWithoutValue(t *testing.T) {
+
+	ta := require.New(t)
+
+	c := iterCases["simple"]
+	keys := c.keys
+
+	st, err := NewSlimTrie(encode.I32{}, keys, nil, Opt{Complete: Bool(true)})
+	ta.NoError(err)
+
+	for _, sk := range c.scanFromKeys {
+		idx := sort.SearchStrings(keys, sk)
+		nxt := st.NewIter(sk, true, true)
+
+		for i := int32(idx); i < int32(len(keys)); i++ {
+			key := keys[i]
+			gotKey, gotVal := nxt()
+			ta.Equal([]byte(key), gotKey, "newIter from: %s %v, idx: %d", sk, []byte(sk), idx)
+			ta.Nil(gotVal, "newIter from: %s %v, idx: %d", sk, []byte(sk), idx)
+		}
+		gotKey, gotVal := nxt()
+		ta.Nil(gotKey)
+		ta.Nil(gotVal)
+	}
+}
+
+func TestSlimTrie_Iter_large(t *testing.T) {
+
+	testBigKeySet(t, func(t *testing.T, keys []string) {
+		ta := require.New(t)
+
+		values := makeI32s(len(keys))
+
+		st, err := NewSlimTrie(encode.I32{}, keys, values, Opt{Complete: Bool(true)})
+		ta.NoError(err)
+
+		subTestIter(t, st, keys, randVStrings(clap(len(keys), 50, 10*1024), 0, 10))
+		subTestScan(t, st, keys, randVStrings(clap(len(keys), 50, 10*1024), 0, 10))
+	})
+}
+
+var OutputIter int
+
+func BenchmarkSlimTrie_Iter(b *testing.B) {
+
+	typ := "1mvl5_10"
+
+	keys := getKeys(typ)
+	n := len(keys)
+	values := makeI32s(n)
+
+	st, err := NewSlimTrie(encode.I32{}, keys, values, Opt{Complete: Bool(true)})
+	if err != nil {
+		panic("err:" + err.Error())
+	}
+
+	scanN := 1024 * 100
+
+	b.ResetTimer()
+
+	s := 0
+
+	for i := 0; i < b.N/scanN; i++ {
+		nxt := st.NewIter("`", true, true)
+		for j := 0; j < scanN; j++ {
+			b, _ := nxt()
+			s += int(b[0])
+
+		}
+	}
+	OutputIter = s
+}
+
+func subTestPath(
+	t *testing.T,
+	st *SlimTrie,
+	keys []string,
+	paths [][]int32,
+	scanFromKeys []string,
+) {
+
+	t.Run("getGEPath", func(t *testing.T) {
+
+		ta := require.New(t)
+
+		// searching from other keys should start from next present key.
+		for _, sk := range scanFromKeys {
+			idx := sort.SearchStrings(keys, sk)
+			p, gotEqual := st.getGEPath(sk)
+			ta.Equal(paths[idx], p, "key: %s %v", sk, []byte(sk))
+			if idx == len(keys) {
+				ta.False(gotEqual)
+			} else {
+				ta.Equal(keys[idx] == sk, gotEqual, "key: %s %v, gotEqual: %v", sk, []byte(sk), gotEqual)
+			}
+		}
+	})
+
+}
+func subTestIter(
+	t *testing.T,
+	st *SlimTrie,
+	keys []string,
+	scanFromKeys []string,
+) {
+	t.Run("NewIter", func(t *testing.T) {
+
+		ta := require.New(t)
+
+		for _, sk := range scanFromKeys {
+			idx := sort.SearchStrings(keys, sk)
+
+			{ // test exclusive
+				nxt := st.NewIter(sk, false, true)
+				gotKey, _ := nxt()
+				if idx == len(keys) {
+					ta.Nil(gotKey, "newIter from: %s %v, idx: %d", sk, []byte(sk), idx)
+				} else {
+					if keys[idx] == sk {
+						ta.NotEqual([]byte(keys[idx]), gotKey, "newIter from: %s %v, idx: %d", sk, []byte(sk), idx)
+					} else {
+						ta.Equal([]byte(keys[idx]), gotKey, "newIter from: %s %v, idx: %d", sk, []byte(sk), idx)
+					}
+				}
+			}
+
+			nxt := st.NewIter(sk, true, true)
+
+			var i int32
+			for i = int32(idx); i < int32(len(keys)) && i < int32(idx+200); i++ {
+				key := keys[i]
+				gotKey, gotVal := nxt()
+				ta.Equal([]byte(key), gotKey, "newIter from: %s %v, idx: %d", sk, []byte(sk), idx)
+				ta.Equal(st.encoder.Encode(i), gotVal, "newIter from: %s %v, idx: %d", sk, []byte(sk), idx)
+			}
+			if i == int32(len(keys)) {
+				ta.Nil(nxt())
+			}
+
+			{ // newIter without yielding value
+				nxt := st.NewIter(sk, true, false)
+				_, gotVal := nxt()
+				ta.Nil(gotVal)
+				_, gotVal = nxt()
+				ta.Nil(gotVal)
+			}
+		}
+	})
+}
+
+func subTestScan(
+	t *testing.T,
+	st *SlimTrie,
+	keys []string,
+	scanFromKeys []string,
+) {
+	t.Run("NewIter", func(t *testing.T) {
+
+		ta := require.New(t)
+
+		for _, sk := range scanFromKeys {
+			idx := sort.SearchStrings(keys, sk)
+
+			{ // exclusive start
+				st.ScanFrom(sk, false, true, func(gotKey, v []byte) bool {
+					if idx == len(keys) {
+						ta.Nil(gotKey, "Scan from: %s %v, idx: %d", sk, []byte(sk), idx)
+					} else {
+						if keys[idx] == sk {
+							ta.NotEqual([]byte(keys[idx]), gotKey, "Scan from: %s %v, idx: %d", sk, []byte(sk), idx)
+						} else {
+							ta.Equal([]byte(keys[idx]), gotKey, "Scan from: %s %v, idx: %d", sk, []byte(sk), idx)
+						}
+					}
+
+					// only check the first key
+					return false
+				})
+			}
+
+			{ // inclusive start
+
+				i := int32(idx)
+				st.ScanFrom(sk, true, true, func(gotKey, gotVal []byte) bool {
+					key := keys[i]
+					ta.Equal([]byte(key), gotKey, "Scan from: %s %v, idx: %d", sk, []byte(sk), idx)
+					ta.Equal(st.encoder.Encode(i), gotVal, "Scan from: %s %v, idx: %d", sk, []byte(sk), idx)
+
+					i++
+					return i <= int32(idx+200)
+				})
+			}
+
+			{ // scan from to
+
+				i := int32(idx)
+				endIdx := i + 50
+				if endIdx >= int32(len(keys)) {
+					endIdx = int32(len(keys)) - 1
+				}
+
+				var endKey string
+				if endIdx == -1 {
+					endKey = "foo"
+				} else {
+					endKey = keys[endIdx]
+				}
+
+				st.ScanFromTo(sk, true,
+					endKey, false,
+					true, func(gotKey, gotVal []byte) bool {
+						key := keys[i]
+						ta.Equal([]byte(key), gotKey, "Scan from: %s %v, idx: %d", sk, []byte(sk), idx)
+						ta.Equal(st.encoder.Encode(i), gotVal, "Scan from: %s %v, idx: %d", sk, []byte(sk), idx)
+						ta.True(string(gotKey) < endKey, "Scan from: %s %v, idx: %d", sk, []byte(sk), idx)
+
+						i++
+						return i <= int32(idx+200)
+					})
+			}
+
+			{ // without yielding value
+				st.ScanFrom(sk, true, false, func(k, v []byte) bool {
+					ta.Nil(v)
+					return false
+				})
+			}
+		}
+	})
+}


### PR DESCRIPTION
# Description

- new-feature: ScanFrom() and ScanFromTo() scans slimtrie with a callback function; NewIter() returns a "next" function to iterate items in slimtrie

  - add: internal method getGEPath() returns whether the path exactly equals to searching key

- internal: slimtrie: add: getIthLeafBytes() returns the ith leaf in bytes.

-  internal: slimtrie: leftMost(): returns the path along which it walks down to the leaf node.

Fixes #80 

## Type of change

<!-- Please delete options that are not relevant. -->

- **New feature**     <!-- non-breaking change which adds functionality -->

@goldsborough please have a look at the API whether it fulfill your need. :DDD
Any other suggestions are appreciated! 🤔 

 