### PR TITLE
fix: scan trie with one key

### DIFF
--- a/trie/slimtrie_scan.go
+++ b/trie/slimtrie_scan.go
@@ -114,6 +114,37 @@ func (st *SlimTrie) newIter(path []int32, skipFirst, withValue bool) NextRaw {
 
 	if skipFirst {
 		stackIdx = next(stack, stackIdx)
+	} else {
+
+		if len(path) == 1 {
+			// SlimTrie is built with only one key.
+			//
+			// The walking algo depends on parent node. If there is only one node in a trie, there is no parent node.
+			// Thus, it is a special case.
+
+			consumed := false
+			nodeId := path[0]
+
+			return func() ([]byte, []byte) {
+				if consumed {
+					return nil, nil
+				}
+
+				var val []byte
+				qr := &querySession{}
+				st.getNode(nodeId, qr)
+				if qr.hasLeafPrefix {
+					buf = append(buf, qr.leafPrefix...)
+				}
+				if withValue {
+					leafI, _ := st.getLeafIndex(nodeId)
+					val = st.getIthLeafBytes(leafI)
+				}
+
+				consumed = true
+				return buf, val
+			}
+		}
 	}
 
 	return func() ([]byte, []byte) {

--- a/trie/slimtrie_scan_test.go
+++ b/trie/slimtrie_scan_test.go
@@ -36,6 +36,12 @@ var iterCases = map[string]struct {
 		paths:        [][]int32{{}},
 		scanFromKeys: defaultScan,
 	},
+	"single": {
+		keys:         []string{"ab"},
+		slimStr:      trim(`#000=0`),
+		paths:        [][]int32{{0}, {}},
+		scanFromKeys: defaultScan,
+	},
 	"simple": {
 		keys: []string{
 			"abc",


### PR DESCRIPTION
Problem:

If there is only one key, the walking algo does not work, because it stores scanning progress on parent node. A one key trie does not have a parent node thus it just return nothing.

Solution:

Treat a one key trie a special case and return an iterator that just returns the only one record.

- Fix: #170
